### PR TITLE
Use isinstance to make it work for subclasses of dict and list

### DIFF
--- a/serialized_redis/__init__.py
+++ b/serialized_redis/__init__.py
@@ -12,7 +12,7 @@ import pickle
 
 class SerializedRedis(Redis):
     def set(self, key, value):
-        is_list_or_dict = type(value) == list or type(value) == dict
+        is_list_or_dict = isinstance(value, list) or isinstance(value, dict)
 
         if is_list_or_dict:
             super(Redis, self).set(key, pickle.dumps(value))


### PR DESCRIPTION
By using isinstance it'll also work for subclasses of list and dict.
